### PR TITLE
Ajusta a posição do logo da prodest no demo

### DIFF
--- a/src/preview.html
+++ b/src/preview.html
@@ -52,8 +52,9 @@
 		}
 		#logo-prodest {
 			position: absolute;
-			bottom: 30px;
-			left: calc(50% - 65px);
+			top: -20px;
+			left: 30px;
+			height: 0;
 			font-size: 130px;
 			color: #646465;
 		}


### PR DESCRIPTION
Nas apresentações feitas, geralmente são utilizados projetores de resolução pequena, dessa forma o logo da prodest fica acima dos demos do Android e iOS. O logo no topo esquerdo fica discreto e não atrapalha a apresentação em resoluções pequenas.